### PR TITLE
Remove ML Frameworks, Update GenAI instructions, Clean Up typescript errors

### DIFF
--- a/frontend/src/components/AppConfig/HomePageCards.tsx
+++ b/frontend/src/components/AppConfig/HomePageCards.tsx
@@ -5,9 +5,9 @@ import { CardElement } from '../Card/Card';
 
 
 const HomePageCards = () => {
-  const [selectedComponent, setSelectedComponent] = useState(null);
+  const [selectedComponent, setSelectedComponent] = useState<string | null>(null);
 
-  const handleClick = (componentName: any) => {
+  const handleClick = (componentName: string) => {
     setSelectedComponent(componentName);
   };
 

--- a/frontend/src/components/AppConfig/HomePageCards.tsx
+++ b/frontend/src/components/AppConfig/HomePageCards.tsx
@@ -42,13 +42,6 @@ const HomePageCards = () => {
             onClick={() => handleClick('LLM')}
           />
         </li>
-        <li>
-          <CardElement
-            title="ML Frameworks"
-            description="Monitor your ML frameworks"
-            onClick={() => handleClick('MLFrameworks')}
-          />
-        </li>
       </ul>
       </div>
       <div>

--- a/frontend/src/components/GenAI/OpenLIT.tsx
+++ b/frontend/src/components/GenAI/OpenLIT.tsx
@@ -16,7 +16,7 @@ const OpenLIT = () => {
         <h3>Instrument your code</h3>
         <p>To begin collecting telemetry data, initialize the `openlit` library at the start of your application. This simple step hooks into your application to start monitoring its performance and behavior.</p>
         <pre>
-        import openlit
+        import openlit{'\n'}
         openlit.init()
         </pre>
         <h3>Install Dashboard</h3>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -35,18 +35,6 @@ export function HomePage() {
           </Card>
           <Card className=''>
             <div className={styles.imageContainer}>
-              <img src={vectordb} alt="" />
-              <div className={styles.textContainer}>
-                <h2>ML Frameworks</h2>
-                <p>Including Pytorch and Tensorflow</p>
-                <LinkButton href='/a/grafana-aio11y-app/MLFrameworksHomePage'>
-                  View Frameworks Dashboard
-                </LinkButton>
-              </div>
-            </div>
-          </Card>
-          <Card className=''>
-            <div className={styles.imageContainer}>
               <div className={styles.textContainer}>
                 <h2>Monitor Generative AI</h2>
                 <p>Monitor your LLM and Vector Database usage</p>

--- a/frontend/src/plugin.json
+++ b/frontend/src/plugin.json
@@ -6,7 +6,9 @@
   "backend": true,
   "executable": "gpx_ai_observability",
   "info": {
-    "keywords": ["app"],
+    "keywords": [
+      "app"
+    ],
     "description": "All in one ai suite",
     "author": {
       "name": "Gtm"
@@ -20,15 +22,6 @@
     "updated": "%TODAY%"
   },
   "includes": [
-
-    {
-      "type": "page",
-      "name": "ML Frameworks",
-      "path": "/a/%PLUGIN_ID%/ml",
-      "role": "Admin",
-      "addToNav": false,
-      "defaultNav": false
-    },
     {
       "type": "page",
       "name": "Infrastructure",
@@ -57,14 +50,6 @@
       "type": "page",
       "name": "GenAI",
       "path": "/a/%PLUGIN_ID%/GenAI",
-      "role": "Admin",
-      "addToNav": true,
-      "defaultNav": false
-    },
-    {
-      "type": "page",
-      "name": "ML Frameworks",
-      "path": "/a/%PLUGIN_ID%/MLFrameworksHomePage",
       "role": "Admin",
       "addToNav": true,
       "defaultNav": false


### PR DESCRIPTION
This update:

- Removes ML Frameworks from the navigation across the site
- Fixes some typescript errors happening when running `yarn dev --watch`
- Adjusts the output of the Gen AI instructions so they are properly displayed on multiple lines