### PR TITLE
fixing spelling issue flagged by linter

### DIFF
--- a/mixin/genai-mixin/.lint
+++ b/mixin/genai-mixin/.lint
@@ -1,6 +1,6 @@
 exclusions:
   panel-title-description-rule:
-    reason: Removed panel title for visual appearence for top stats panels
+    reason: Removed panel title for visual appearance for top stats panels
   target-job-rule:
     reason: Using OpenLIT which doesn't generate job label
   target-instance-rule:

--- a/mixin/gpu-mixin/.lint
+++ b/mixin/gpu-mixin/.lint
@@ -1,6 +1,6 @@
 exclusions:
   panel-title-description-rule:
-    reason: Removed panel title for visual appearence for top stats panels
+    reason: Removed panel title for visual appearance for top stats panels
   target-job-rule:
     reason: Using OpenLIT which doesn't generate job label
   target-instance-rule:


### PR DESCRIPTION
The linter in cloud-onboarding has identified a spelling error and blocked the build
https://drone.grafana.net/grafana/cloud-onboarding/38663/12/6

